### PR TITLE
Additional test for demonstrating possible issues

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -220,4 +220,38 @@ describe('Exported helpers', () => {
             ]);
         });
     });
+
+    describe('Known limitations', () => {
+        test('Julian/Gregorian calendar change (OCT 1582)', () => {
+            // Note: if the JavaScript native Date-object was adhering to calendar changes,
+            // this test would be missing 10 days between OCT4 and OCT15 due to switching
+            // from Julian to Gregorian calendar, basically like this:
+            //
+            // expect(daysOfYM(1582, 10)).toEqual([
+            //     1, 2, 3, 4, 15, 16, 17,
+            //     18, 19, 20, 21, 22, 23, 24,
+            //     25, 26, 27, 28, 29, 30, 31,
+            // ]);
+            //
+            // However... since the Date-object is not "Julian-aware", the test results in
+            // a far less "weird looking", though historically kinda inexact (neither the
+            // Julian nor Gregorian calendars officially have the missing dates because of
+            // the transition) result:
+
+            expect(daysOfYM(1582, 10)).toEqual([
+                0, 0, 0, 0, 1, 2, 3,
+                4, 5, 6, 7, 8, 9, 10,
+                11, 12, 13, 14, 15, 16, 17,
+                18, 19, 20, 21, 22, 23, 24,
+                25, 26, 27, 28, 29, 30, 31,
+            ]);
+
+            // This is a limitation of JavaScript's native Date-implementation. If there
+            // ever comes a need to observe different calendar types, this test needs to
+            // be updated accordingly with the new implementation.
+            //
+            // In theory this shouldn't be an issue for my personal use cases, but for
+            // others, your mileage may vary.
+        });
+    });
 });


### PR DESCRIPTION
This test was suggested to me personally in order to demonstrate a basic real life difficulty when handling dates around specific "magic" dates - in this case the original transition period from Julian to Gregorian calendar in October 1582 which literally is supposed to "skip" 10 days.

JavaScript's native Date-object does not handle Julian dates; instead, it does represent what the dates would have been if the Gregorian calendar had been in use non-stop throughout history. This is generally just fine for most real life cases where calendar only needs to show accurate dates not further back in the past than four and a half century, which generally is "good enough" for most developers (sure; not all, I'm certain there are developers working on much more complex needs for handling dates) of modern software.

For historical accuracy, though, this can definitely lead to problems. However, I believe that in such cases the date value is most likely the least of the issues that need to be thought out and - in any case - this package likely isn't the best solution for those situations. Some additional issues I can easily come up with off the top of my head are:

* handling chinese, japanese, buddhist, muslim, hebrew, etc. calendars (that   are still widely used around the world)
* how to visually represent what calendar is in use
* mixing & matching the various calendars

That is a can of worms I don't really feel comfortable opening at this time.

Because of this, I created this one test to demonstrate that there are known limitations in the package; they are known, but not addressed in implementation.